### PR TITLE
Fix an issue in getCMakeBinDir function

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -8,6 +8,41 @@ const path = require('node:path');
 const glob = require('@actions/glob');
 const { XMLParser, XMLValidator } = require('fast-xml-parser');
 
+// --- CI/CD Agnostic Helpers ---
+
+const isGitHub = process.env.GITHUB_ACTIONS === 'true';
+
+/**
+ * Sets an environment variable for the current and subsequent actions in the job.
+ * The variable will be available to scripts running in the job.
+ *
+ * @param {string} name The name of the environment variable.
+ * @param {string} value The value of the environment variable.
+ */
+function exportVariable(name, value) {
+  if (isGitHub) {
+    core.exportVariable(name, value);
+  } else {
+    // Azure DevOps logging command to set a variable
+    console.log(`##vso[task.setvariable variable=${name}]${value}`);
+  }
+}
+
+/**
+ * Adds a directory to the system's PATH environment variable for the current and subsequent actions in the job.
+ *
+ * @param {string} path The directory to add to the PATH.
+ */
+function addPath(path) {
+  if (isGitHub) {
+    core.addPath(path);
+  } else {
+    // Azure DevOps logging command to prepend a path
+    console.log(`##vso[task.prependpath]${path}`);
+  }
+}
+
+
 // --- Execution Helper ---
 
 /**
@@ -455,4 +490,6 @@ module.exports = {
   getArchIdentifier,
   checkPathExists,
   generateTestSummary,
+  exportVariable,
+  addPath,
 };

--- a/src/format-lint-check/index.js
+++ b/src/format-lint-check/index.js
@@ -6,7 +6,7 @@ const path = require('node:path');
 const fs = require('node:fs/promises');
 const crypto = require('node:crypto');
 const os = require('node:os');
-const { addPath } = require('../common/ci');
+const { addPath } = require('../common/utils');
 
 // --- SHA256 Verification Helper ---
 /**

--- a/src/format-lint-check/index.js
+++ b/src/format-lint-check/index.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 const fs = require('node:fs/promises');
 const crypto = require('node:crypto');
 const os = require('node:os');
+const { addPath } = require('../common/ci');
 
 // --- SHA256 Verification Helper ---
 /**
@@ -142,7 +143,7 @@ async function run() {
         throw new Error(`LLVM 'bin' directory not found at: ${llvmBinPath}`);
     }
     core.info(`Adding LLVM bin directory to PATH: ${llvmBinPath}`);
-    core.addPath(llvmBinPath);
+    addPath(llvmBinPath);
     try {
       // Verify clang-format exists in PATH *and* store the command name/path
       // Use 'which' to confirm it's findable and potentially get full path if needed later

--- a/src/setup-build-tools/index.js
+++ b/src/setup-build-tools/index.js
@@ -33,7 +33,7 @@ async function getLatestCMakeVersion(githubToken) {
 }
 
 function getCMakeBinDir(cmakePath, platform) {
-  if (platform === 'darwin') {
+  if (platform === 'macos') {
     const macOsBinPath = path.join(cmakePath, 'CMake.app', 'Contents', 'bin');
     if (fs.existsSync(macOsBinPath)) {
       return macOsBinPath;

--- a/src/setup-build-tools/index.js
+++ b/src/setup-build-tools/index.js
@@ -8,6 +8,7 @@ const os = require('node:os');
 
 // Import shared utilities
 const { executeCommand, verifySHA512, getPlatformIdentifier, getArchIdentifier } = require('../common/utils');
+const { addPath, exportVariable } = require('../common/ci');
 
 // --- CMake Specific Helper ---
 async function getLatestCMakeVersion(githubToken) {
@@ -338,7 +339,7 @@ async function run() {
 
     if (addCMakeToPath) {
       core.info(`Adding ${cmakeBinPath} to PATH.`);
-      core.addPath(cmakeBinPath);
+      addPath(cmakeBinPath);
 
       // Verify Installation via PATH
       await core.group('Verifying CMake installation via PATH', async () => {
@@ -383,7 +384,7 @@ async function run() {
 
     // Set vcpkg Environment Variable & Output
     core.info(`Setting VCPKG_INSTALLATION_ROOT to ${finalVcpkgPath}`);
-    core.exportVariable('VCPKG_INSTALLATION_ROOT', finalVcpkgPath);
+    exportVariable('VCPKG_INSTALLATION_ROOT', finalVcpkgPath);
     core.setOutput('vcpkg-root', finalVcpkgPath);
     core.info('vcpkg setup complete.');
     core.endGroup(); // End vcpkg setup group

--- a/src/setup-build-tools/index.js
+++ b/src/setup-build-tools/index.js
@@ -7,8 +7,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 
 // Import shared utilities
-const { executeCommand, verifySHA512, getPlatformIdentifier, getArchIdentifier } = require('../common/utils');
-const { addPath, exportVariable } = require('../common/ci');
+const { executeCommand, verifySHA512, getPlatformIdentifier, getArchIdentifier, addPath, exportVariable } = require('../common/utils');
 
 // --- CMake Specific Helper ---
 async function getLatestCMakeVersion(githubToken) {

--- a/test/setup-build-tools/index.test.js
+++ b/test/setup-build-tools/index.test.js
@@ -15,13 +15,13 @@ describe('getCMakeBinDir', () => {
     const cmakePath = '/path/to/cmake';
     const macOsBinPath = path.join(cmakePath, 'CMake.app', 'Contents', 'bin');
     fs.existsSync.mockReturnValue(true);
-    expect(getCMakeBinDir(cmakePath, 'darwin')).toBe(macOsBinPath);
+    expect(getCMakeBinDir(cmakePath, 'macos')).toBe(macOsBinPath);
   });
 
   it('should return the default bin path for macos when the specific path does not exist', () => {
     const cmakePath = '/path/to/cmake';
     const expectedPath = path.join(cmakePath, 'bin');
     fs.existsSync.mockReturnValue(false);
-    expect(getCMakeBinDir(cmakePath, 'darwin')).toBe(expectedPath);
+    expect(getCMakeBinDir(cmakePath, 'macos')).toBe(expectedPath);
   });
 });


### PR DESCRIPTION
1. This PR fixes a platform identification bug in the getCMakeBinDir function. The function was incorrectly checking for 'darwin' instead of 'macos', causing it to fail when used with the platform identifier from getPlatformIdentifier() which converts 'darwin' to 'macos'

2. Add a wrapper around the "core.exportVariable" function and "core.addPath" function so that the scripts can support both Azure DevOps and Github Actions. 