### PR TITLE
feat: add & use CCache w/ setup-build-tools, build-ort, and build-minimal-ort

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,11 +37,12 @@ jobs:
       - name: Test setup-build-tools action (Linux)
         uses: ./build/setup-build-tools
         with:
+          ccache-version: 4.13.1
+          ccache-hash: 626407a9b81dd86f8ec9867bff396b32dd1f00344f5b323526579a64f6d4104927f83e8d7a05ad9806fd78f4491e0adb4cff73388000a62050cb1b00766214ee
           cmake-version: '4.0.0'
           cmake-hash: '8482e754bf5bf45349ba2f2184999f81f8754ed3d281e1708f1f9a3b2fcd05c3aa5368e6247930495722ffc5982aadbe489630c5716241ab1702c3cf866483cf'
           vcpkg-version: '2025.03.19'
           vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
-          add-to-path: 'true'
           disable-terrapin: 'true'
 
   windows-ci-no-downloader:
@@ -78,11 +79,12 @@ jobs:
       - name: Test setup-build-tools action (Windows)
         uses: ./build/setup-build-tools
         with:
+          ccache-version: 4.13.1
+          ccache-hash: 626407a9b81dd86f8ec9867bff396b32dd1f00344f5b323526579a64f6d4104927f83e8d7a05ad9806fd78f4491e0adb4cff73388000a62050cb1b00766214ee
           cmake-version: '4.0.0'
           cmake-hash: '704fc67b9efa1d65e68a516b439ce3f65f1d6388dc0794002a342d4b59cd3ea63619e674d0343a08c03e9831b053bcbb3ae7635ac42f7796b8d440deeb81b7f6'
           vcpkg-version: '2025.03.19'
           vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
-          add-to-path: 'true'
           disable-terrapin: 'true'
 
       - name: Verify CMake Installation (Windows)
@@ -147,11 +149,12 @@ jobs:
       - name: Test setup-build-tools action (Windows)
         uses: ./build/setup-build-tools
         with:
+          ccache-version: 4.13.1
+          ccache-hash: 626407a9b81dd86f8ec9867bff396b32dd1f00344f5b323526579a64f6d4104927f83e8d7a05ad9806fd78f4491e0adb4cff73388000a62050cb1b00766214ee
           cmake-version: '4.0.0'
           cmake-hash: '704fc67b9efa1d65e68a516b439ce3f65f1d6388dc0794002a342d4b59cd3ea63619e674d0343a08c03e9831b053bcbb3ae7635ac42f7796b8d440deeb81b7f6'
           vcpkg-version: '2025.03.19'
           vcpkg-hash: '17e96169cd3f266c4716fcdc1bb728e6a64f103941ece463a2834d50694eba4fb48f30135503fd466402afa139abc847ef630733c442595d1c34979f261b0114'
-          add-to-path: 'true'
           terrapin-tool-path: ${{ github.workspace }}/test/cpp/terrapin_tool.exe
 
       - name: Verify CMake Installation (Windows)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
         uses: ./build/setup-build-tools
         with:
           ccache-version: 4.13.1
-          ccache-hash: 626407a9b81dd86f8ec9867bff396b32dd1f00344f5b323526579a64f6d4104927f83e8d7a05ad9806fd78f4491e0adb4cff73388000a62050cb1b00766214ee
+          ccache-hash: fe678d8e82f35e1d5f13c7bcd86447c08b67b0831dec8c772ef1257090a0f51678e296bb6d3ea38433f472d0fded52da96445cbc6fa8f945ecf94351d2c149d8
           cmake-version: '4.0.0'
           cmake-hash: '704fc67b9efa1d65e68a516b439ce3f65f1d6388dc0794002a342d4b59cd3ea63619e674d0343a08c03e9831b053bcbb3ae7635ac42f7796b8d440deeb81b7f6'
           vcpkg-version: '2025.03.19'
@@ -150,7 +150,7 @@ jobs:
         uses: ./build/setup-build-tools
         with:
           ccache-version: 4.13.1
-          ccache-hash: 626407a9b81dd86f8ec9867bff396b32dd1f00344f5b323526579a64f6d4104927f83e8d7a05ad9806fd78f4491e0adb4cff73388000a62050cb1b00766214ee
+          ccache-hash: fe678d8e82f35e1d5f13c7bcd86447c08b67b0831dec8c772ef1257090a0f51678e296bb6d3ea38433f472d0fded52da96445cbc6fa8f945ecf94351d2c149d8
           cmake-version: '4.0.0'
           cmake-hash: '704fc67b9efa1d65e68a516b439ce3f65f1d6388dc0794002a342d4b59cd3ea63619e674d0343a08c03e9831b053bcbb3ae7635ac42f7796b8d440deeb81b7f6'
           vcpkg-version: '2025.03.19'

--- a/actions/setup-build-tools/action.yml
+++ b/actions/setup-build-tools/action.yml
@@ -1,5 +1,5 @@
 name: 'Setup Build Tools (CMake & vcpkg)'
-description: 'Downloads, verifies, extracts, caches CMake and vcpkg. Optionally adds CMake to PATH and sets VCPKG_INSTALLATION_ROOT.'
+description: 'Downloads, verifies, extracts, and caches tooling. Optionally adds tools to PATH and sets VCPKG_INSTALLATION_ROOT.'
 
 inputs:
   # --- CCache Inputs ---

--- a/actions/setup-build-tools/action.yml
+++ b/actions/setup-build-tools/action.yml
@@ -4,7 +4,7 @@ description: 'Downloads, verifies, extracts, caches CMake and vcpkg. Optionally 
 inputs:
   # --- CMake Inputs ---
   cmake-version:
-    description: 'The CMake version to download (e.g., 3.28.3) or "latest".'
+    description: 'The CMake version to download (e.g., 3.28.3).'
     required: true
   cmake-hash:
     description: SHA512 of archive.
@@ -31,10 +31,6 @@ inputs:
     description: 'Set to true to bypass Terrapin for both downloads and use direct download instead.'
     required: false
     default: 'false'
-  github-token:
-    description: 'GitHub token used for fetching the "latest" CMake version via API.'
-    required: false
-    default: ${{ github.token }} # Default to the workflow token
 
 outputs:
   # --- CMake Outputs ---

--- a/actions/setup-build-tools/action.yml
+++ b/actions/setup-build-tools/action.yml
@@ -2,6 +2,18 @@ name: 'Setup Build Tools (CMake & vcpkg)'
 description: 'Downloads, verifies, extracts, caches CMake and vcpkg. Optionally adds CMake to PATH and sets VCPKG_INSTALLATION_ROOT.'
 
 inputs:
+  # --- CCache Inputs ---
+  ccache-version:
+    description: 'The CCache version to download (e.g., 4.13).'
+    required: true
+  ccache-hash:
+    description: SHA512 of archive.
+    required: true
+  add-ccache-to-path:
+    description: 'If true, add the CCache bin directory to the PATH environment variable.'
+    required: false
+    default: 'true'
+
   # --- CMake Inputs ---
   cmake-version:
     description: 'The CMake version to download (e.g., 3.28.3).'
@@ -33,6 +45,12 @@ inputs:
     default: 'false'
 
 outputs:
+  # --- CCache Outputs ---
+  ccache-root:
+    description: 'The root directory path of the cached CCache installation.'
+  ccache-path:
+    description: 'The path to the directory containing the CCache executables (added to PATH if add-ccache-to-path is true).'
+
   # --- CMake Outputs ---
   cmake-root:
     description: 'The root directory path of the cached CMake installation.'

--- a/actions/setup-build-tools/action.yml
+++ b/actions/setup-build-tools/action.yml
@@ -7,10 +7,8 @@ inputs:
     description: 'The CMake version to download (e.g., 3.28.3) or "latest".'
     required: true
   cmake-hash:
-    description: >
-      Optional. The expected SHA512 hash of the CMake archive for the target platform.
-      Required for verification and Terrapin usage for CMake.
-    required: false
+    description: SHA512 of archive.
+    required: true
   add-cmake-to-path:
     description: 'If true, add the CMake bin directory to the PATH environment variable.'
     required: false

--- a/src/build-and-prep-ort-files/index.js
+++ b/src/build-and-prep-ort-files/index.js
@@ -17,7 +17,7 @@ async function runCommand(command, args = [], options = {}) {
     const effectiveOptions = {
         cwd: defaultCwd, // Apply default
         ignoreReturnCode: false, // Throw error on failure by default
-        silent: false, // Show command output by default        
+        silent: false, // Show command output by default
         ...options // Apply overrides from caller (like cwd)
     };
 
@@ -28,9 +28,9 @@ async function runCommand(command, args = [], options = {}) {
         const { exitCode, stdout, stderr } = await exec.getExecOutput(command, args, effectiveOptions);
 
         if (exitCode !== 0 && !effectiveOptions.ignoreReturnCode) {
-             // Log stderr specifically as error if command failed
-             core.error(`Stderr: ${stderr}`);
-             throw new Error(`Command exited with code ${exitCode}: ${command} ${args.join(' ')}`);
+            // Log stderr specifically as error if command failed
+            core.error(`Stderr: ${stderr}`);
+            throw new Error(`Command exited with code ${exitCode}: ${command} ${args.join(' ')}`);
         }
         core.info(`Finished: ${command} ${args.join(' ')}`);
         return { exitCode, stdout, stderr };
@@ -98,6 +98,7 @@ async function main() {
             '--config', 'Debug',
             '--skip_submodule_sync',
             '--parallel',
+            '--use_cache',
             '--use_vcpkg',
             '--use_vcpkg_ms_internal_asset_cache',
             '--use_binskim_compliant_compile_flags',
@@ -108,7 +109,10 @@ async function main() {
             '--use_coreml'
         ];
         // Run build from the workspace directory
+        await runCommand('ccache', ['--version']);
+        await runCommand('ccache', ['--zero-stats']);
         await runCommand('python3', buildArgs, { cwd: workspaceDir });
+        await runCommand('ccache', ['--show-stats', '-vv']); // assume a modern ccache was provided by `setup-build-tools` action
         core.endGroup();
 
         // --- Step 4: Install the ORT Python Wheel ---
@@ -183,9 +187,9 @@ async function main() {
         let filesCopied = 0;
         try {
             const customOpOnnxFiles = (await fs.readdir(customOpSrcDir)).filter(f => f.endsWith('.onnx'));
-             if (customOpOnnxFiles.length === 0) {
+            if (customOpOnnxFiles.length === 0) {
                 core.warning(`No .onnx files found in ${customOpSrcDir} to copy.`);
-             } else {
+            } else {
                 for (const file of customOpOnnxFiles) {
                     const src = path.join(customOpSrcDir, file);
                     const dest = path.join(customOpsTestDataDir, file);
@@ -193,9 +197,9 @@ async function main() {
                     core.info(`Copied ${file}`);
                     filesCopied++;
                 }
-             }
-             core.info(`Copied ${filesCopied} custom op model files.`);
-        } catch(copyError) {
+            }
+            core.info(`Copied ${filesCopied} custom op model files.`);
+        } catch (copyError) {
             core.warning(`Could not copy custom op models from ${customOpSrcDir}: ${copyError.message}`);
         }
 

--- a/src/build-minimal-ort-and-run-tests/index.js
+++ b/src/build-minimal-ort-and-run-tests/index.js
@@ -198,7 +198,10 @@ async function main() {
             core.info('Input `enable-type-reduction` is true. Assuming the provided `reduced-ops-config-file` was generated with type reduction enabled.');
         }
 
+        await runCommand('ccache', ['--version']);
+        await runCommand('ccache', ['--zero-stats']);
         await runCommand('python3', buildArgs.filter(arg => arg !== ''), { cwd: workspaceDir }); // Filter empty string from minimalBuildArgs
+        await runCommand('ccache', ['--show-stats', '-vv']); // assume a modern ccache was provided by `setup-build-tools` action
         core.endGroup();
 
         // --- Run E2E Model Tests ---

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -34,10 +34,9 @@ function exportVariable(name, value) {
  * @param {string} path The directory to add to the PATH.
  */
 function addPath(path) {
-  if (isGitHub) {
-    core.addPath(path);
-  } else {
-    // Azure DevOps logging command to prepend a path
+  core.addPath(path);
+  if (!isGitHub) {
+    // Azure DevOps logging command to prepend a path, otherwise it won't persist for subsequent tasks
     console.log(`##vso[task.prependpath]${path}`);
   }
 }
@@ -59,7 +58,7 @@ async function executeCommand(command, args, options = {}) {
     options.sensitive && process.env.GITHUB_TOKEN && arg === process.env.GITHUB_TOKEN
       ? '***' // Mask GITHUB_TOKEN if sensitive option is true
       : // Add more conditions here for other sensitive args if needed
-        arg
+      arg
   );
 
   // Log the command with potentially masked arguments
@@ -251,12 +250,12 @@ async function generateTestSummary(baseDir) {
   const allTestCases = []; // <--- NEW: Array to store individual test cases {suite, case, time}
 
   const parserOptions = {
-      ignoreAttributes: false,
-      attributeNamePrefix: "", // No prefix for attributes
-      parseAttributeValue: true, // Convert attribute values to primitive types if possible
-      allowBooleanAttributes: true,
-      trimValues: true,
-      ignoreDeclaration: true
+    ignoreAttributes: false,
+    attributeNamePrefix: "", // No prefix for attributes
+    parseAttributeValue: true, // Convert attribute values to primitive types if possible
+    allowBooleanAttributes: true,
+    trimValues: true,
+    ignoreDeclaration: true
   };
   const parser = new XMLParser(parserOptions);
 
@@ -268,144 +267,144 @@ async function generateTestSummary(baseDir) {
 
     const globber = await glob.create(xmlPattern, { followSymbolicLinks: false });
     for await (const file of globber.globGenerator()) {
-        filesProcessed++;
-        const fileName = path.relative(baseDir, file) || path.basename(file);
-        processedFiles.push(fileName);
-        core.debug(`--- Processing file: ${fileName} ---`);
-        let fileContent;
+      filesProcessed++;
+      const fileName = path.relative(baseDir, file) || path.basename(file);
+      processedFiles.push(fileName);
+      core.debug(`--- Processing file: ${fileName} ---`);
+      let fileContent;
 
-        // Reset counters for the current file before processing
-        let fileTests = 0, fileFailures = 0, fileErrors = 0, fileSkipped = 0;
+      // Reset counters for the current file before processing
+      let fileTests = 0, fileFailures = 0, fileErrors = 0, fileSkipped = 0;
 
-        try {
-            fileContent = await fs.readFile(file, 'utf8');
-            const validationResult = XMLValidator.validate(fileContent);
-            if (validationResult !== true) {
-                const err = validationResult.err;
-                core.warning(`Invalid XML syntax in ${fileName}: ${err.msg} (Line: ${err.line}, Col: ${err.col})`);
-                failedFiles.push(`${fileName} (syntax error)`);
-                continue;
-            }
-
-            const result = parser.parse(fileContent);
-            core.debug(`Parsed XML structure: ${JSON.stringify(result, null, 2)}`);
-
-            const rootKey = Object.keys(result)[0];
-            if (!rootKey) {
-                core.warning(`Could not determine root tag in ${fileName}.`);
-                failedFiles.push(`${fileName} (structure error - no root key)`);
-                continue;
-            }
-            const topLevelData = result[rootKey]; // This is the object/array under the root tag
-
-            core.debug(`Root Key: ${rootKey}, Top Level Data Type: ${typeof topLevelData}`);
-
-            let suitesToProcess = [];
-
-            if (rootKey === 'testsuites') {
-                // Root is <testsuites>, contains potentially multiple <testsuite>
-                if (topLevelData && topLevelData.testsuite) {
-                    suitesToProcess = Array.isArray(topLevelData.testsuite)
-                        ? topLevelData.testsuite
-                        : [topLevelData.testsuite];
-                    core.debug(`Found ${suitesToProcess.length} <testsuite> elements under <testsuites>`);
-                } else {
-                     core.debug(`<testsuites> root found, but no child <testsuite> elements detected.`);
-                     // Check <testsuites> attributes for summary (less common)
-                    if (typeof topLevelData === 'object' && topLevelData !== null) {
-                        const attrs = topLevelData;
-                        const t = Number(attrs.tests || 0);
-                        const f = Number(attrs.failures || 0);
-                        const e = Number(attrs.errors || 0);
-                        const s = Number(attrs.skipped || attrs.disabled || 0);
-                        if (!isNaN(t) && !isNaN(f) && !isNaN(e) && !isNaN(s) && (t > 0 || f > 0 || e > 0 || s > 0)) {
-                            fileTests = t; fileFailures = f; fileErrors = e; fileSkipped = s;
-                            core.debug(`Using summary counts found directly on <testsuites> tag.`);
-                        }
-                    }
-                }
-            } else if (rootKey === 'testsuite') {
-                // Root is a single <testsuite>
-                if (topLevelData) {
-                    suitesToProcess = [topLevelData]; // Process this single suite
-                    core.debug(`Root is a single <testsuite> element.`);
-                }
-            } else {
-                core.warning(`Unexpected root tag <${rootKey}> found in ${fileName}. Skipping counts.`);
-                failedFiles.push(`${fileName} (unexpected root tag)`);
-                continue; // Skip count aggregation for this file
-            }
-
-            // Iterate through the identified testsuite objects
-            for (const suite of suitesToProcess) {
-                if (typeof suite === 'object' && suite !== null) {
-                    core.debug(`Processing suite object: ${JSON.stringify(suite, null, 2)}`);
-                    const suiteName = suite.name || 'UnknownSuite'; // Get suite name
-                    const attrs = suite;
-
-                    // Aggregate counts from suite attributes
-                    const t = Number(attrs.tests || 0);
-                    const f = Number(attrs.failures || 0);
-                    const e = Number(attrs.errors || 0);
-                    const s = Number(attrs.skipped ?? attrs.disabled ?? 0);
-
-                    if (isNaN(t) || isNaN(f) || isNaN(e) || isNaN(s)) {
-                         core.warning(`Non-numeric test counts found in attributes of a <testsuite name="${suiteName}"> tag in ${fileName}.`);
-                    } else {
-                        fileTests += t;
-                        fileFailures += f;
-                        fileErrors += e;
-                        fileSkipped += s;
-                    }
-
-                    // --- NEW: Process individual test cases ---
-                    if (suite.testcase) {
-                        const testCases = Array.isArray(suite.testcase) ? suite.testcase : [suite.testcase];
-                        core.debug(` Found ${testCases.length} <testcase> elements in suite "${suiteName}"`);
-                        for (const tc of testCases) {
-                            if (typeof tc === 'object' && tc !== null) {
-                                const caseName = tc.name;
-                                const caseTime = tc.time; // Should be parsed as number by parseAttributeValue: true
-
-                                // Check if data is valid for sorting
-                                if (caseName && typeof caseTime === 'number' && !isNaN(caseTime)) {
-                                    allTestCases.push({
-                                        suite: suiteName,
-                                        case: caseName,
-                                        time: caseTime
-                                    });
-                                    core.debug(`  Added test case: ${suiteName} / ${caseName} / ${caseTime}`);
-                                } else {
-                                    core.debug(`  Skipping test case with missing name or invalid time: ${JSON.stringify(tc)}`);
-                                }
-                            }
-                        }
-                    } else {
-                         core.debug(` No <testcase> elements found in suite "${suiteName}"`);
-                    }
-                    // --- End NEW ---
-
-                } else {
-                    core.warning(`Encountered non-object item in suitesToProcess for ${fileName}. Skipping item.`);
-                }
-            } // End loop through suitesToProcess
-
-             // Add file totals to overall totals outside the suite loop
-             totalTests += fileTests;
-             totalFailures += fileFailures;
-             totalErrors += fileErrors;
-             totalSkipped += fileSkipped;
-             core.debug(` -> Aggregated Counts for ${fileName} - Tests: ${fileTests}, Failures: ${fileFailures}, Errors: ${fileErrors}, Skipped: ${fileSkipped}`);
-             core.debug(` -> Running Totals - Tests: ${totalTests}, Failures: ${totalFailures}, Errors: ${totalErrors}, Skipped: ${totalSkipped}`);
-
-
-        } catch (error) {
-            const errorCode = error.code ? ` (${error.code})` : '';
-            core.warning(`Error processing file ${fileName}${errorCode}: ${error.message}`);
-            core.debug(error.stack); // Log stack for debug
-            failedFiles.push(`${fileName} (processing error)`);
+      try {
+        fileContent = await fs.readFile(file, 'utf8');
+        const validationResult = XMLValidator.validate(fileContent);
+        if (validationResult !== true) {
+          const err = validationResult.err;
+          core.warning(`Invalid XML syntax in ${fileName}: ${err.msg} (Line: ${err.line}, Col: ${err.col})`);
+          failedFiles.push(`${fileName} (syntax error)`);
+          continue;
         }
-        core.debug(`--- Finished processing file: ${fileName} ---`);
+
+        const result = parser.parse(fileContent);
+        core.debug(`Parsed XML structure: ${JSON.stringify(result, null, 2)}`);
+
+        const rootKey = Object.keys(result)[0];
+        if (!rootKey) {
+          core.warning(`Could not determine root tag in ${fileName}.`);
+          failedFiles.push(`${fileName} (structure error - no root key)`);
+          continue;
+        }
+        const topLevelData = result[rootKey]; // This is the object/array under the root tag
+
+        core.debug(`Root Key: ${rootKey}, Top Level Data Type: ${typeof topLevelData}`);
+
+        let suitesToProcess = [];
+
+        if (rootKey === 'testsuites') {
+          // Root is <testsuites>, contains potentially multiple <testsuite>
+          if (topLevelData && topLevelData.testsuite) {
+            suitesToProcess = Array.isArray(topLevelData.testsuite)
+              ? topLevelData.testsuite
+              : [topLevelData.testsuite];
+            core.debug(`Found ${suitesToProcess.length} <testsuite> elements under <testsuites>`);
+          } else {
+            core.debug(`<testsuites> root found, but no child <testsuite> elements detected.`);
+            // Check <testsuites> attributes for summary (less common)
+            if (typeof topLevelData === 'object' && topLevelData !== null) {
+              const attrs = topLevelData;
+              const t = Number(attrs.tests || 0);
+              const f = Number(attrs.failures || 0);
+              const e = Number(attrs.errors || 0);
+              const s = Number(attrs.skipped || attrs.disabled || 0);
+              if (!isNaN(t) && !isNaN(f) && !isNaN(e) && !isNaN(s) && (t > 0 || f > 0 || e > 0 || s > 0)) {
+                fileTests = t; fileFailures = f; fileErrors = e; fileSkipped = s;
+                core.debug(`Using summary counts found directly on <testsuites> tag.`);
+              }
+            }
+          }
+        } else if (rootKey === 'testsuite') {
+          // Root is a single <testsuite>
+          if (topLevelData) {
+            suitesToProcess = [topLevelData]; // Process this single suite
+            core.debug(`Root is a single <testsuite> element.`);
+          }
+        } else {
+          core.warning(`Unexpected root tag <${rootKey}> found in ${fileName}. Skipping counts.`);
+          failedFiles.push(`${fileName} (unexpected root tag)`);
+          continue; // Skip count aggregation for this file
+        }
+
+        // Iterate through the identified testsuite objects
+        for (const suite of suitesToProcess) {
+          if (typeof suite === 'object' && suite !== null) {
+            core.debug(`Processing suite object: ${JSON.stringify(suite, null, 2)}`);
+            const suiteName = suite.name || 'UnknownSuite'; // Get suite name
+            const attrs = suite;
+
+            // Aggregate counts from suite attributes
+            const t = Number(attrs.tests || 0);
+            const f = Number(attrs.failures || 0);
+            const e = Number(attrs.errors || 0);
+            const s = Number(attrs.skipped ?? attrs.disabled ?? 0);
+
+            if (isNaN(t) || isNaN(f) || isNaN(e) || isNaN(s)) {
+              core.warning(`Non-numeric test counts found in attributes of a <testsuite name="${suiteName}"> tag in ${fileName}.`);
+            } else {
+              fileTests += t;
+              fileFailures += f;
+              fileErrors += e;
+              fileSkipped += s;
+            }
+
+            // --- NEW: Process individual test cases ---
+            if (suite.testcase) {
+              const testCases = Array.isArray(suite.testcase) ? suite.testcase : [suite.testcase];
+              core.debug(` Found ${testCases.length} <testcase> elements in suite "${suiteName}"`);
+              for (const tc of testCases) {
+                if (typeof tc === 'object' && tc !== null) {
+                  const caseName = tc.name;
+                  const caseTime = tc.time; // Should be parsed as number by parseAttributeValue: true
+
+                  // Check if data is valid for sorting
+                  if (caseName && typeof caseTime === 'number' && !isNaN(caseTime)) {
+                    allTestCases.push({
+                      suite: suiteName,
+                      case: caseName,
+                      time: caseTime
+                    });
+                    core.debug(`  Added test case: ${suiteName} / ${caseName} / ${caseTime}`);
+                  } else {
+                    core.debug(`  Skipping test case with missing name or invalid time: ${JSON.stringify(tc)}`);
+                  }
+                }
+              }
+            } else {
+              core.debug(` No <testcase> elements found in suite "${suiteName}"`);
+            }
+            // --- End NEW ---
+
+          } else {
+            core.warning(`Encountered non-object item in suitesToProcess for ${fileName}. Skipping item.`);
+          }
+        } // End loop through suitesToProcess
+
+        // Add file totals to overall totals outside the suite loop
+        totalTests += fileTests;
+        totalFailures += fileFailures;
+        totalErrors += fileErrors;
+        totalSkipped += fileSkipped;
+        core.debug(` -> Aggregated Counts for ${fileName} - Tests: ${fileTests}, Failures: ${fileFailures}, Errors: ${fileErrors}, Skipped: ${fileSkipped}`);
+        core.debug(` -> Running Totals - Tests: ${totalTests}, Failures: ${totalFailures}, Errors: ${totalErrors}, Skipped: ${totalSkipped}`);
+
+
+      } catch (error) {
+        const errorCode = error.code ? ` (${error.code})` : '';
+        core.warning(`Error processing file ${fileName}${errorCode}: ${error.message}`);
+        core.debug(error.stack); // Log stack for debug
+        failedFiles.push(`${fileName} (processing error)`);
+      }
+      core.debug(`--- Finished processing file: ${fileName} ---`);
     } // End for loop over files
 
     // --- Generate Summary Markdown ---
@@ -426,33 +425,32 @@ async function generateTestSummary(baseDir) {
       summaryMarkdown += `| Metric        | Count |\n`;
       summaryMarkdown += `| ------------- | ----: |\n`;
       summaryMarkdown += `| Total Tests   | ${totalTests} |\n`;
-      summaryMarkdown += `| Failures      | ${
-        totalFailures > 0 ? `**${totalFailures}** ❌` : totalFailures
-      } |\n`;
+      summaryMarkdown += `| Failures      | ${totalFailures > 0 ? `**${totalFailures}** ❌` : totalFailures
+        } |\n`;
       summaryMarkdown += `| Errors        | ${totalErrors > 0 ? `**${totalErrors}** ❌` : totalErrors} |\n`;
       summaryMarkdown += `| Skipped       | ${totalSkipped} |\n`;
       summaryMarkdown += `| **Overall** | **${overallStatus}** |\n\n`;
 
       // --- NEW: Generate Top 10 Slowest Tests ---
       if (allTestCases.length > 0) {
-            // Sort by time descending
-            allTestCases.sort((a, b) => b.time - a.time);
-            const slowestTests = allTestCases.slice(0, 10);
+        // Sort by time descending
+        allTestCases.sort((a, b) => b.time - a.time);
+        const slowestTests = allTestCases.slice(0, 10);
 
-            summaryMarkdown += `### Top ${slowestTests.length} Slowest Tests\n\n`;
-            summaryMarkdown += `| Rank | Time (s) | Suite Name      | Test Case Name  |\n`;
-            summaryMarkdown += `| ---- | -------- | --------------- | --------------- |\n`;
-            slowestTests.forEach((test, index) => {
-                // Format time to 3 decimal places
-                const timeFormatted = test.time.toFixed(3);
-                // Escape pipe characters in names to prevent breaking markdown table
-                const suiteEscaped = test.suite.replace(/([\\|])/g, '\\$1');
-                const caseEscaped = test.case.replace(/([\\|])/g, '\\$1');
-                summaryMarkdown += `| ${index + 1} | ${timeFormatted} | ${suiteEscaped} | ${caseEscaped} |\n`;
-            });
-            summaryMarkdown += '\n';
+        summaryMarkdown += `### Top ${slowestTests.length} Slowest Tests\n\n`;
+        summaryMarkdown += `| Rank | Time (s) | Suite Name      | Test Case Name  |\n`;
+        summaryMarkdown += `| ---- | -------- | --------------- | --------------- |\n`;
+        slowestTests.forEach((test, index) => {
+          // Format time to 3 decimal places
+          const timeFormatted = test.time.toFixed(3);
+          // Escape pipe characters in names to prevent breaking markdown table
+          const suiteEscaped = test.suite.replace(/([\\|])/g, '\\$1');
+          const caseEscaped = test.case.replace(/([\\|])/g, '\\$1');
+          summaryMarkdown += `| ${index + 1} | ${timeFormatted} | ${suiteEscaped} | ${caseEscaped} |\n`;
+        });
+        summaryMarkdown += '\n';
       } else {
-           summaryMarkdown += `No individual test case times found to determine slowest tests.\n\n`;
+        summaryMarkdown += `No individual test case times found to determine slowest tests.\n\n`;
       }
       // --- End NEW ---
 
@@ -475,11 +473,11 @@ async function generateTestSummary(baseDir) {
     }
 
   } catch (error) {
-      if (error.code === 'ENOENT') {
-        core.info(`Test result base directory ${baseDir} not found. Skipping summary generation.`);
-      } else {
-        core.error(`Error reading test result directory ${baseDir} or globbing files: ${error.message}`);
-      }
+    if (error.code === 'ENOENT') {
+      core.info(`Test result base directory ${baseDir} not found. Skipping summary generation.`);
+    } else {
+      core.error(`Error reading test result directory ${baseDir} or globbing files: ${error.message}`);
+    }
   } finally {
     core.endGroup();
   }

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -103,10 +103,16 @@ async function verifySHA512(filePath, expectedHash) {
     stream.on('data', (chunk) => hash.update(chunk));
     stream.on('end', () => {
       const actualHash = hash.digest('hex');
-      core.debug(`Actual SHA512: ${actualHash}`);
-      core.debug(`Expected SHA512: ${expectedHash}`);
       const match = actualHash.toLowerCase() === expectedHash.toLowerCase();
-      core.info(`SHA512 Verification Result for ${path.basename(filePath)}: ${match ? 'Match' : 'Mismatch'}`);
+      if (match) {
+        core.debug(`SHA512 hash matches for file: ${filePath}`);
+        core.debug(`SHA512: '${actualHash.toLowerCase()}'`);
+      } else {
+        core.warning(`Actual   SHA512: '${actualHash.toLowerCase()}'`);
+        core.warning(`Expected SHA512: '${expectedHash.toLowerCase()}'`);
+        core.warning(`SHA512 hash mismatch for file: ${filePath}`);
+      }
+
       resolve(match);
     });
   });

--- a/src/run-build-script-in-docker/index.js
+++ b/src/run-build-script-in-docker/index.js
@@ -132,7 +132,6 @@ async function run() {
         const homeDir = os.homedir();
         const homeOnnxDir = path.join(homeDir, '.onnx');
         const hostCacheDir = path.join(homeDir, '.cache');
-        const hostCCacheDir = path.join(homeDir, '.ccache');
         const containerHomeDir = containerUser ? `/home/${containerUser}` : '/root';
         if (!workspaceDir) throw new Error('GITHUB_WORKSPACE not set.');
 
@@ -143,8 +142,6 @@ async function run() {
         const dataModelsExists = await checkPathExists(hostDataModelsPath);
         const enableOnnxTestsFlag = dataOnnxExists && dataModelsExists;
         core.info(`--enable_onnx_tests will be ${enableOnnxTestsFlag ? 'added' : 'skipped'}.`);
-
-        await fs.mkdir(hostCCacheDir, { recursive: true }); // ensure ccache exists for mounting
 
         // --- Check for GPU ---
         const gpuAvailable = await checkGpu();
@@ -221,7 +218,6 @@ async function run() {
         dockerArgs.push('--volume', `${workspaceDir}:/onnxruntime_src`);
         dockerArgs.push('--volume', `${runnerTempDir}:/onnxruntime_src/build`);
         dockerArgs.push('--volume', `${hostCacheDir}:${containerHomeDir}/.cache`); // Use determined container home
-        dockerArgs.push('--volume', `${hostCCacheDir}:${containerHomeDir}/.ccache`);
         if (lowerCaseRunMode === 'test') {
             core.info('Mode is "test", checking test data mounts.');
             if (dataOnnxExists) {
@@ -249,6 +245,7 @@ async function run() {
         dockerArgs.push('-e', `ALLOW_RELEASED_ONNX_OPSET_ONLY=${allowOpset}`);
         dockerArgs.push('-e', `NIGHTLY_BUILD=${nightlyBuild}`);
         dockerArgs.push('-e', 'RUNNER_TEMP=/onnxruntime_src/build');
+        dockerArgs.push('-e', `CCACHE_DIR=${containerHomeDir}/.cache/ccache`); // be explicit, in case this is an older version of ccache
         dockerArgs.push(dockerImage);
         // Pass the full command sequence
         dockerArgs.push('/bin/bash', '-c', fullDockerCommand);

--- a/src/setup-build-tools/index.js
+++ b/src/setup-build-tools/index.js
@@ -93,7 +93,7 @@ async function downloadArchive(terrapinTool, downloadUrl, hash) {
   }
 
   if (!fs.existsSync(downloadedFile)) { // Verify download happened
-    throw new Error(`vcpkg download failed: Expected file not found at ${downloadedFile}.`);
+    throw new Error(`download failed, expected file not found at: ${downloadedFile}`);
   }
 
   try {

--- a/src/setup-build-tools/index.js
+++ b/src/setup-build-tools/index.js
@@ -14,27 +14,6 @@ const { executeCommand, verifySHA512, getPlatformIdentifier, getArchIdentifier, 
 const TERRAPIN_BASE_URL = 'https://vcpkg.storage.devpackages.microsoft.io/artifacts/';
 
 // --- CMake Specific Helper ---
-async function getLatestCMakeVersion(githubToken) {
-  core.info('Querying GitHub API for the latest CMake release...');
-  if (!githubToken) throw new Error('GitHub token not provided to getLatestCMakeVersion.');
-  const octokit = github.getOctokit(githubToken);
-  try {
-    const latestRelease = await octokit.rest.repos.getLatestRelease({ owner: 'Kitware', repo: 'CMake' });
-    const tagName = latestRelease.data.tag_name;
-    if (!tagName || !tagName.startsWith('v')) {
-      throw new Error(`Unexpected tag format for latest CMake release: ${tagName}`);
-    }
-    const version = tagName.substring(1);
-    core.info(`Latest CMake version found: ${version}`);
-    return version;
-  } catch (error) {
-    core.error(`Failed to fetch latest CMake release: ${error.message}`);
-    if (error.status === 403 || error.status === 401) {
-      core.warning('GitHub API rate limit/auth error checking latest CMake version.');
-    }
-    throw error; // Re-throw error to fail the action if 'latest' was requested
-  }
-}
 
 function getCMakeBinDir(cmakePath, platform) {
   if (platform === 'macos') {
@@ -129,10 +108,6 @@ async function downloadArchive(terrapinTool, downloadUrl, hash) {
   return downloadedFile;
 }
 
-async function downloadVcpkgZip(terrapinTool, version, hash) {
-  return await downloadArchive(terrapinTool, `https://github.com/microsoft/vcpkg/archive/refs/tags/${version}.zip`, hash)
-}
-
 async function extractVcpkgZip(downloadedZipPath) {
   core.info(`Extracting vcpkg archive: ${path.basename(downloadedZipPath)}...`);
   const tempExtractPath = await tc.extractZip(downloadedZipPath);
@@ -200,170 +175,122 @@ async function bootstrapVcpkg(extractedPath) {
   core.info('vcpkg bootstrapped successfully.');
 }
 
-async function cacheVcpkgDir(extractedPath, toolName, version) {
-  core.info(`Caching bootstrapped vcpkg directory: ${extractedPath}`);
-  const finalPath = await tc.cacheDir(extractedPath, toolName, version);
-  core.info(`Successfully cached vcpkg to: ${finalPath}`);
-  return finalPath;
+async function cacheTool(terrapinTool, toolName, version, url, hash, extract) {
+  const archKey = `${getPlatformIdentifier()}-${getArchIdentifier()}`;
+  const cachedDir = tc.find(toolName, version, archKey);
+  if (cachedDir) {
+    core.info(`Found cached ${toolName} at: ${cachedDir}`);
+    return cachedDir;
+  }
+
+  const downloadFile = await downloadArchive(terrapinTool, url, hash)
+  let extractDir;
+  try {
+    extractDir = await extract(downloadFile);
+  } finally {
+    try {
+      fs.unlinkSync(downloadFile);
+      core.debug(`Cleaned up downloaded archive: ${downloadFile}`);
+    } catch (e) {
+      core.warning(`Failed to delete downloaded archive '${downloadFile}': ${e.message}`);
+    }
+  }
+
+  const toolDir = await tc.cacheDir(extractDir, toolName, version, archKey);
+  core.debug(`Cached ${toolName} at: ${toolDir}`);
+  return toolDir;
 }
 
-// --- Shared Helper ---
-function cleanupDownload(downloadedPath) {
-  try {
-    if (downloadedPath && fs.existsSync(downloadedPath)) {
-      fs.unlinkSync(downloadedPath);
-      core.info(`Cleaned up downloaded ${toolName} archive: ${downloadedPath}`);
+async function run__cmake(terrapinTool, version, hash, addToPath) {
+  const platform = getPlatformIdentifier();
+  const arch = getArchIdentifier();
+  const cmakeFileExtension = platform === 'windows' ? 'zip' : 'tar.gz';
+  const cmakeFileName = `cmake-${version}-${platform}-${arch}`;
+
+  const cmakeDir = await cacheTool(
+    terrapinTool,
+    "cmake", version,
+    `https://github.com/Kitware/CMake/releases/download/v${version}/${cmakeFileName}.${cmakeFileExtension}`, hash,
+    async (download) => {
+      core.debug(`Extracting ${download}...`);
+      const extractDir = cmakeFileExtension === 'zip'
+        ? await tc.extractZip(download)
+        : await tc.extractTar(download);
+      core.debug(`Extracted CMake archive to temporary location: ${extractDir}`);
+
+      // Locate CMake Directory
+      const maybeRoot = path.join(extractDir, cmakeFileName);
+      if (fs.existsSync(maybeRoot) && fs.statSync(maybeRoot).isDirectory())
+        return maybeRoot;
+
+      const dirs = fs.readdirSync(extractDir).filter((f) => fs.statSync(path.join(extractDir, f)).isDirectory());
+      if (dirs.length !== 1) throw new Error(
+        `Could not locate extracted CMake directory in ${extractDir}. Found: ${dirs.join(', ')}`
+      );
+
+      core.warning(`Assuming single directory '${dirs[0]}' is CMake root.`);
+      return path.join(extractDir, dirs[0]);
+    });
+  core.info(`Located extracted CMake root at: ${cmakeDir}`);
+
+  // Add CMake to PATH (if requested)
+  const binPath = getCMakeBinDir(cmakeDir, platform);
+  if (!fs.existsSync(binPath)) throw new Error(`CMake 'bin' directory not found: ${binPath}`);
+
+  if (addToPath) {
+    core.info(`Adding ${binPath} to PATH.`);
+    addPath(binPath);
+
+    try {
+      // Verify Installation via PATH
+      await exec.exec('cmake', ['--version']);
+    } catch (error) {
+      throw new Error(`Verification 'cmake --version' failed: ${error.message}. Check PATH or CMake installation.`, { cause: error });
     }
-  } catch (e) {
-    core.warning(`Failed to delete downloaded ${toolName} archive '${downloadedPath}': ${e.message}`);
+  } else {
+    core.info(`Skipping adding ${binPath} to PATH.`);
   }
+
+  // Set CMake Outputs
+  core.setOutput('cmake-root', cmakeDir);
+  core.setOutput('cmake-path', binPath);
+}
+
+async function run__vcpkg(terrapinTool, version, hash) {
+  const vcpkgDir = await cacheTool(
+    terrapinTool,
+    "vcpkg", normalizeVcpkgVersion(version),
+    `https://github.com/microsoft/vcpkg/archive/refs/tags/${version}.zip`, hash,
+    async (download) => {
+      const extracted = await extractVcpkgZip(download);
+      const extractedActual = findActualVcpkgDir(extracted, version);
+      await bootstrapVcpkg(extractedActual);
+      return extractedActual;
+    });
+  exportVariable('VCPKG_INSTALLATION_ROOT', vcpkgDir);
+  core.setOutput('vcpkg-root', vcpkgDir);
 }
 
 // --- Main Orchestration Function ---
 async function run() {
-  let cmakeDownloadedArchivePath; // Track potential CMake download path for cleanup
-  let vcpkgDownloadedZipPath; // Track potential vcpkg download path for cleanup
-
   try {
     // --- Get Combined Inputs ---
-    const cmakeVersionInput = core.getInput('cmake-version', { required: true });
+    const cmakeVersion = core.getInput('cmake-version', { required: true });
     const cmakeHash = core.getInput('cmake-hash', { required: true });
+    const addCMakeToPath = core.getBooleanInput('add-cmake-to-path');
+
     const vcpkgVersion = core.getInput('vcpkg-version', { required: true });
     const vcpkgHash = core.getInput('vcpkg-hash', { required: true });
+
     const terrapinPath = core.getInput('terrapin-tool-path');
     const allowTerrapin = !core.getBooleanInput('disable-terrapin'); // keep logic positive to minimise double negatives
-    const addCMakeToPath = core.getBooleanInput('add-cmake-to-path');
-    const githubToken = core.getInput('github-token'); // Use default from action.yml
-
-    const platform = getPlatformIdentifier();
-    const arch = getArchIdentifier();
-    const runnerTempDir = process.env.RUNNER_TEMP || os.tmpdir();
-    if (!runnerTempDir) throw new Error('Runner temporary directory not found.');
 
     const terrapinTool = terrapinAvailable(terrapinPath, allowTerrapin) ? terrapinPath : null;
-
-    // === CMake Setup ===
-    core.startGroup('Setup CMake');
-    const cmakeToolName = 'cmake';
-
-    // Resolve CMake Version
-    let resolvedCmakeVersion = cmakeVersionInput;
-    if (cmakeVersionInput.toLowerCase() === 'latest') {
-      core.info('Resolving "latest" CMake version via GitHub API...');
-      resolvedCmakeVersion = await getLatestCMakeVersion(githubToken);
-    }
-    core.info(`Setting up CMake version: ${resolvedCmakeVersion} for ${platform}-${arch}`);
-
-    // CMake Cache Check
-    const cmakeCacheKeyArch = `${platform}-${arch}`;
-    let cmakeRootPath = tc.find(cmakeToolName, resolvedCmakeVersion, cmakeCacheKeyArch);
-
-    if (cmakeRootPath) {
-      core.info(`Found cached CMake at: ${cmakeRootPath}`);
-    } else {
-      // CMake Cache Miss Logic
-      core.info(`CMake version ${resolvedCmakeVersion} (${cmakeCacheKeyArch}) not found in cache. Downloading...`);
-
-      const cmakeFileExtension = platform === 'windows' ? 'zip' : 'tar.gz';
-      const cmakeFileName = platform === 'macos' && arch === 'universal'
-        ? `cmake-${resolvedCmakeVersion}-macos-universal`
-        : `cmake-${resolvedCmakeVersion}-${platform}-${arch}`;
-      const cmakeDownloadUrl = `https://github.com/Kitware/CMake/releases/download/v${resolvedCmakeVersion}/${cmakeFileName}.${cmakeFileExtension}`;
-      const cmakeDownloadedArchivePath = await downloadArchive(terrapinTool, cmakeDownloadUrl, cmakeHash);
-
-      core.debug(`Extracting ${cmakeDownloadedArchivePath}...`);
-      const cmakeTempExtractPath = cmakeFileExtension === 'zip'
-        ? await tc.extractZip(cmakeDownloadedArchivePath)
-        : await tc.extractTar(cmakeDownloadedArchivePath);
-      core.debug(`Extracted CMake archive to temporary location: ${cmakeTempExtractPath}`);
-
-      // Locate CMake Directory
-      const cmakePotentialRoot = path.join(cmakeTempExtractPath, cmakeFileName);
-      if (fs.existsSync(cmakePotentialRoot) && fs.statSync(cmakePotentialRoot).isDirectory()) {
-        cmakeRootPath = cmakePotentialRoot;
-      } else {
-        const files = fs.readdirSync(cmakeTempExtractPath);
-        const dirs = files.filter((f) => fs.statSync(path.join(cmakeTempExtractPath, f)).isDirectory());
-        if (dirs.length === 1) {
-          cmakeRootPath = path.join(cmakeTempExtractPath, dirs[0]);
-          core.warning(`Assuming single directory '${dirs[0]}' is CMake root.`);
-        } else {
-          throw new Error(
-            `Could not locate extracted CMake directory in ${cmakeTempExtractPath}. Found: ${dirs.join(', ')}`
-          );
-        }
-      }
-      core.info(`Located extracted CMake root at: ${cmakeRootPath}`);
-
-      // Cache CMake Directory
-      core.info(`Caching CMake directory: ${cmakeRootPath}`);
-      cmakeRootPath = await tc.cacheDir(cmakeRootPath, cmakeToolName, resolvedCmakeVersion, cmakeCacheKeyArch);
-      core.info(`Successfully cached CMake to: ${cmakeRootPath}`);
-
-      // Cleanup handled in finally block
-    } // End CMake cache miss
-
-    // Add CMake to PATH (if requested)
-    const cmakeBinPath = getCMakeBinDir(cmakeRootPath, platform);
-    if (!fs.existsSync(cmakeBinPath)) throw new Error(`CMake 'bin' directory not found: ${cmakeBinPath}`);
-
-    if (addCMakeToPath) {
-      core.info(`Adding ${cmakeBinPath} to PATH.`);
-      addPath(cmakeBinPath);
-
-      // Verify Installation via PATH
-      await core.group('Verifying CMake installation via PATH', async () => {
-        try {
-          await exec.exec('cmake', ['--version']);
-        } catch (error) {
-          core.warning(`Verification 'cmake --version' failed: ${error.message}. Check PATH or CMake installation.`);
-        }
-      });
-    } else {
-      core.info(`Skipping adding ${cmakeBinPath} to PATH.`);
-    }
-
-    // Set CMake Outputs
-    core.setOutput('cmake-root', cmakeRootPath);
-    core.setOutput('cmake-path', cmakeBinPath);
-    core.info(`CMake ${resolvedCmakeVersion} setup complete.`);
-    core.endGroup(); // End CMake setup group
-
-    // === vcpkg Setup ===
-    core.startGroup('Setup vcpkg');
-    const vcpkgToolName = 'vcpkg';
-    const normalizedVcpkgVersion = normalizeVcpkgVersion(vcpkgVersion);
-    core.info(`Setting up vcpkg version: ${vcpkgVersion} (normalized to ${normalizedVcpkgVersion})`);
-
-    // vcpkg Cache Check
-    let finalVcpkgPath = tc.find(vcpkgToolName, normalizedVcpkgVersion); // vcpkg cache key seems simpler
-
-    if (finalVcpkgPath) {
-      core.info(`Found cached vcpkg at: ${finalVcpkgPath}`);
-    } else {
-      // vcpkg Cache Miss Logic
-      core.info(`vcpkg version ${vcpkgVersion} not found in cache. Downloading...`);
-      vcpkgDownloadedZipPath = await downloadVcpkgZip(terrapinTool, vcpkgVersion, vcpkgHash); // Track for cleanup
-      const vcpkgTempExtractPath = await extractVcpkgZip(vcpkgDownloadedZipPath);
-      const vcpkgExtractedPath = findActualVcpkgDir(vcpkgTempExtractPath, vcpkgVersion);
-      await bootstrapVcpkg(vcpkgExtractedPath);
-      finalVcpkgPath = await cacheVcpkgDir(vcpkgExtractedPath, vcpkgToolName, normalizedVcpkgVersion);
-      // Cleanup handled in finally block
-    } // End vcpkg cache miss
-
-    // Set vcpkg Environment Variable & Output
-    core.info(`Setting VCPKG_INSTALLATION_ROOT to ${finalVcpkgPath}`);
-    exportVariable('VCPKG_INSTALLATION_ROOT', finalVcpkgPath);
-    core.setOutput('vcpkg-root', finalVcpkgPath);
-    core.info('vcpkg setup complete.');
-    core.endGroup(); // End vcpkg setup group
+    await core.group(`Setup cmake`, async () => { await run__cmake(terrapinTool, cmakeVersion, cmakeHash, addCMakeToPath) });
+    await core.group(`Setup vcpkg`, async () => { await run__vcpkg(terrapinTool, vcpkgVersion, vcpkgHash) });
   } catch (error) {
     // Fail the action with the error message
     core.setFailed(error.message);
-  } finally {
-    // Cleanup downloads only if they were actually performed (i.e., path variable is set)
-    cleanupDownload(cmakeDownloadedArchivePath, 'CMake');
-    cleanupDownload(vcpkgDownloadedZipPath, 'vcpkg');
   }
 }
 

--- a/src/setup-build-tools/index.js
+++ b/src/setup-build-tools/index.js
@@ -1,7 +1,6 @@
 const core = require('@actions/core');
 const tc = require('@actions/tool-cache');
 const exec = require('@actions/exec');
-const github = require('@actions/github');
 const path = require('node:path');
 const assert = require('node:assert');
 const crypto = require("node:crypto");

--- a/src/setup-build-tools/index.js
+++ b/src/setup-build-tools/index.js
@@ -3,7 +3,7 @@ const tc = require('@actions/tool-cache');
 const exec = require('@actions/exec');
 const path = require('node:path');
 const assert = require('node:assert');
-const crypto = require("node:crypto");
+const crypto = require('node:crypto');
 const fs = require('node:fs');
 const os = require('node:os');
 

--- a/src/setup-build-tools/index.js
+++ b/src/setup-build-tools/index.js
@@ -3,11 +3,15 @@ const tc = require('@actions/tool-cache');
 const exec = require('@actions/exec');
 const github = require('@actions/github');
 const path = require('node:path');
+const assert = require('node:assert');
+const crypto = require("node:crypto");
 const fs = require('node:fs');
 const os = require('node:os');
 
 // Import shared utilities
 const { executeCommand, verifySHA512, getPlatformIdentifier, getArchIdentifier, addPath, exportVariable } = require('../common/utils');
+
+const TERRAPIN_BASE_URL = 'https://vcpkg.storage.devpackages.microsoft.io/artifacts/';
 
 // --- CMake Specific Helper ---
 async function getLatestCMakeVersion(githubToken) {
@@ -55,24 +59,45 @@ function normalizeVcpkgVersion(version) {
 
 // --- vcpkg Specific Helpers ---
 
-async function downloadVcpkgZip(version, hash, terrapinPath, disableTerrapin) {
-  let downloadedZipPath;
-  const downloadUrl = `https://github.com/microsoft/vcpkg/archive/refs/tags/${version}.zip`;
+function terrapinAvailable(terrapinPath, allowTerrapin) {
+  if (!allowTerrapin) {
+    core.info('Terrapin usage disabled.');
+    return false;
+  }
+
+  if (!terrapinPath) {
+    core.info('Terrapin tool path not provided or unavailable.');
+    return false;
+  }
+
+  if (!fs.existsSync(terrapinPath)) {
+    core.warning(`Terrapin tool path provided but not found at '${terrapinPath}'.`);
+    return false;
+  }
+
+  core.info(`Using Terrapin tool @ ${terrapinPath}`);
+  return true;
+}
+
+// PRECONDITION: `terrapinTool` != null <> `terrapinTool` exists on disk and we should use it
+async function downloadArchive(terrapinTool, downloadUrl, hash) {
+  // Not robust/correct, but whatever. Keep the extension for the file b/c some tools try to infer behaviour from it.
+  // e.g. `tar`
+  const runnerTempDir = process.env.RUNNER_TEMP || os.tmpdir();
+  if (!runnerTempDir) throw new Error('Could not determine temporary directory for download.');
+
+  // Not robust/correct, but whatever. Keep the filename for the file b/c some tools try to infer behaviour from it.
+  // e.g. `tar` can infer the compression type.
+  const baseName = path.basename(downloadUrl);
+  const downloadedFile = path.join(runnerTempDir, `${crypto.randomUUID()}_${baseName}`); // random name to avoid conflicts/security issues
 
   // Use Terrapin if: path provided, path exists, Terrapin NOT disabled
   // Note: vcpkg requires hash, so hash presence check isn't needed here like for cmake
-  const canUseTerrapin = terrapinPath && !disableTerrapin && fs.existsSync(terrapinPath);
-
-  if (canUseTerrapin) {
-    core.info(`Using Terrapin Tool for vcpkg at: ${terrapinPath}`);
-    const runnerTempDir = process.env.RUNNER_TEMP || os.tmpdir();
-    if (!runnerTempDir) throw new Error('Could not determine temporary directory for vcpkg download.');
-    downloadedZipPath = path.join(runnerTempDir, `vcpkg-${version}.zip`); // More specific name
-    core.info(`Terrapin will download vcpkg to: ${downloadedZipPath}`);
-    const terrapinBaseUrl = 'https://vcpkg.storage.devpackages.microsoft.io/artifacts/';
-    const terrapinArgs = [
+  if (terrapinTool) {
+    // Quote command path in case it contains spaces. Underlying API is poorly designed and doesn't handle this.
+    await core.group(`Downloading ${downloadUrl} via Terrapin Tool`, async () => await executeCommand(`"${terrapinTool}"`, [
       '-b',
-      terrapinBaseUrl,
+      TERRAPIN_BASE_URL,
       '-a',
       'true',
       '-u',
@@ -82,33 +107,30 @@ async function downloadVcpkgZip(version, hash, terrapinPath, disableTerrapin) {
       '-s',
       hash,
       '-d',
-      downloadedZipPath,
-    ];
-    await core.group('Downloading vcpkg via Terrapin Tool', async () => {
-      // Quote path in case it contains spaces
-      await executeCommand(`"${terrapinPath}"`, terrapinArgs);
-    });
-    core.info(`Download vcpkg via Terrapin completed.`);
+      downloadedFile,
+    ]));
   } else {
-    // Log reason for not using Terrapin
-    if (terrapinPath && !fs.existsSync(terrapinPath)) {
-      core.warning(
-        `Terrapin tool path provided but not found at '${terrapinPath}'. Attempting direct download for vcpkg.`
-      );
-    } else if (disableTerrapin) {
-      core.info('Terrapin usage disabled. Attempting direct download for vcpkg.');
-    } else {
-      core.info('Terrapin tool path not provided or unavailable. Attempting direct download for vcpkg.');
-    }
-    // Direct download
-    downloadedZipPath = await tc.downloadTool(downloadUrl);
-    core.info(`Direct download for vcpkg completed. Archive at: ${downloadedZipPath}`);
+    const result = await core.group(`Downloading ${downloadUrl} directly`, async () => await tc.downloadTool(downloadUrl, downloadedFile));
+    assert.strictEqual(result, downloadedFile, `Unexpected download location returned by tool-cache: ${result} (expected: ${downloadedFile})`);
   }
-  // Verify download happened
-  if (!fs.existsSync(downloadedZipPath)) {
-    throw new Error(`vcpkg download failed: Expected file not found at ${downloadedZipPath}.`);
+
+  if (!fs.existsSync(downloadedFile)) { // Verify download happened
+    throw new Error(`vcpkg download failed: Expected file not found at ${downloadedFile}.`);
   }
-  return downloadedZipPath;
+
+  try {
+    // Ostensibly terrapin should already have validated this on that branch, but I cannot confirm given the lack of documentation/access to the tool.
+    if (!await verifySHA512(downloadedFile, hash)) // does *NOT* throws on mismatch
+      throw new Error(`SHA512 hash mismatch for downloaded file at ${downloadedFile}.`);
+  } catch (error) {
+    fs.unlinkSync(downloadedFile); // do not leave unverified files around
+    throw error;
+  }
+  return downloadedFile;
+}
+
+async function downloadVcpkgZip(terrapinTool, version, hash) {
+  return await downloadArchive(terrapinTool, `https://github.com/microsoft/vcpkg/archive/refs/tags/${version}.zip`, hash)
 }
 
 async function extractVcpkgZip(downloadedZipPath) {
@@ -186,7 +208,7 @@ async function cacheVcpkgDir(extractedPath, toolName, version) {
 }
 
 // --- Shared Helper ---
-function cleanupDownload(downloadedPath, toolName = 'Archive') {
+function cleanupDownload(downloadedPath) {
   try {
     if (downloadedPath && fs.existsSync(downloadedPath)) {
       fs.unlinkSync(downloadedPath);
@@ -205,11 +227,11 @@ async function run() {
   try {
     // --- Get Combined Inputs ---
     const cmakeVersionInput = core.getInput('cmake-version', { required: true });
-    const cmakeHash = core.getInput('cmake-hash'); // Optional
+    const cmakeHash = core.getInput('cmake-hash', { required: true });
     const vcpkgVersion = core.getInput('vcpkg-version', { required: true });
-    const vcpkgHash = core.getInput('vcpkg-hash', { required: true }); // Required
+    const vcpkgHash = core.getInput('vcpkg-hash', { required: true });
     const terrapinPath = core.getInput('terrapin-tool-path');
-    const disableTerrapin = core.getBooleanInput('disable-terrapin');
+    const allowTerrapin = !core.getBooleanInput('disable-terrapin'); // keep logic positive to minimise double negatives
     const addCMakeToPath = core.getBooleanInput('add-cmake-to-path');
     const githubToken = core.getInput('github-token'); // Use default from action.yml
 
@@ -218,9 +240,10 @@ async function run() {
     const runnerTempDir = process.env.RUNNER_TEMP || os.tmpdir();
     if (!runnerTempDir) throw new Error('Runner temporary directory not found.');
 
+    const terrapinTool = terrapinAvailable(terrapinPath, allowTerrapin) ? terrapinPath : null;
+
     // === CMake Setup ===
     core.startGroup('Setup CMake');
-    const cmakeHasHash = cmakeHash && cmakeHash.trim() !== '';
     const cmakeToolName = 'cmake';
 
     // Resolve CMake Version
@@ -242,69 +265,17 @@ async function run() {
       core.info(`CMake version ${resolvedCmakeVersion} (${cmakeCacheKeyArch}) not found in cache. Downloading...`);
 
       const cmakeFileExtension = platform === 'windows' ? 'zip' : 'tar.gz';
-      let cmakeFileName = `cmake-${resolvedCmakeVersion}-${platform}-${arch}`;
-      if (platform === 'macos' && arch === 'universal') cmakeFileName = `cmake-${resolvedCmakeVersion}-macos-universal`;
-      const cmakeArchiveFileName = `${cmakeFileName}.${cmakeFileExtension}`;
-      const cmakeDownloadUrl = `https://github.com/Kitware/CMake/releases/download/v${resolvedCmakeVersion}/${cmakeArchiveFileName}`;
-      core.info(`CMake Download URL: ${cmakeDownloadUrl}`);
+      const cmakeFileName = platform === 'macos' && arch === 'universal'
+        ? `cmake-${resolvedCmakeVersion}-macos-universal`
+        : `cmake-${resolvedCmakeVersion}-${platform}-${arch}`;
+      const cmakeDownloadUrl = `https://github.com/Kitware/CMake/releases/download/v${resolvedCmakeVersion}/${cmakeFileName}.${cmakeFileExtension}`;
+      const cmakeDownloadedArchivePath = await downloadArchive(terrapinTool, cmakeDownloadUrl, cmakeHash);
 
-      // Determine CMake Download Method
-      const cmakeCanUseTerrapin =
-        platform === 'windows' && cmakeHasHash && !disableTerrapin && fs.existsSync(terrapinPath);
-      core.info(`Attempting CMake download via ${cmakeCanUseTerrapin ? 'Terrapin' : 'direct download'}`);
-      if (!cmakeHasHash && !cmakeCanUseTerrapin) {
-        // Warn only if direct downloading without hash
-        core.warning('CMake SECURITY RISK: `cmake-hash` not provided. Integrity will NOT be verified.');
-      }
-
-      // Download CMake
-      const cmakeTempDownloadPath = path.join(runnerTempDir, cmakeArchiveFileName);
-      if (cmakeCanUseTerrapin) {
-        const terrapinBaseUrl = 'https://vcpkg.storage.devpackages.microsoft.io/artifacts/';
-        const terrapinArgs = [
-          '-b',
-          terrapinBaseUrl,
-          '-a',
-          'true',
-          '-u',
-          'Environment',
-          '-p',
-          cmakeDownloadUrl,
-          '-s',
-          cmakeHash,
-          '-d',
-          cmakeTempDownloadPath,
-        ];
-        await core.group('Downloading CMake via Terrapin Tool', async () => {
-          await executeCommand(`"${terrapinPath}"`, terrapinArgs);
-        });
-        cmakeDownloadedArchivePath = cmakeTempDownloadPath; // Track for cleanup
-      } else {
-        await core.group('Downloading CMake directly', async () => {
-          cmakeDownloadedArchivePath = await tc.downloadTool(cmakeDownloadUrl, cmakeTempDownloadPath); // Track for cleanup
-        });
-      }
-      core.info(`CMake download completed. Archive at: ${cmakeDownloadedArchivePath}`);
-      if (!fs.existsSync(cmakeDownloadedArchivePath))
-        throw new Error(`CMake download failed: File not found at ${cmakeDownloadedArchivePath}`);
-
-      // Verify CMake Hash (if provided)
-      if (cmakeHasHash) {
-        core.info('Verifying CMake SHA512 hash...');
-        const cmakeHashMatch = await verifySHA512(cmakeDownloadedArchivePath, cmakeHash);
-        if (!cmakeHashMatch) {
-          cleanupDownload(cmakeDownloadedArchivePath, 'CMake (mismatched hash)'); // Attempt cleanup before throwing
-          throw new Error('CMake SHA512 hash verification failed!');
-        }
-        core.info('CMake SHA512 hash verification successful.');
-      }
-
-      // Extract CMake
-      core.info(`Extracting ${cmakeArchiveFileName}...`);
-      let cmakeTempExtractPath;
-      if (cmakeFileExtension === 'zip') cmakeTempExtractPath = await tc.extractZip(cmakeDownloadedArchivePath);
-      else cmakeTempExtractPath = await tc.extractTar(cmakeDownloadedArchivePath);
-      core.info(`Extracted CMake archive to temporary location: ${cmakeTempExtractPath}`);
+      core.debug(`Extracting ${cmakeDownloadedArchivePath}...`);
+      const cmakeTempExtractPath = cmakeFileExtension === 'zip'
+        ? await tc.extractZip(cmakeDownloadedArchivePath)
+        : await tc.extractTar(cmakeDownloadedArchivePath);
+      core.debug(`Extracted CMake archive to temporary location: ${cmakeTempExtractPath}`);
 
       // Locate CMake Directory
       const cmakePotentialRoot = path.join(cmakeTempExtractPath, cmakeFileName);
@@ -372,8 +343,7 @@ async function run() {
     } else {
       // vcpkg Cache Miss Logic
       core.info(`vcpkg version ${vcpkgVersion} not found in cache. Downloading...`);
-      vcpkgDownloadedZipPath = await downloadVcpkgZip(vcpkgVersion, vcpkgHash, terrapinPath, disableTerrapin); // Track for cleanup
-      await verifySHA512(vcpkgDownloadedZipPath, vcpkgHash); // Throws on mismatch
+      vcpkgDownloadedZipPath = await downloadVcpkgZip(terrapinTool, vcpkgVersion, vcpkgHash); // Track for cleanup
       const vcpkgTempExtractPath = await extractVcpkgZip(vcpkgDownloadedZipPath);
       const vcpkgExtractedPath = findActualVcpkgDir(vcpkgTempExtractPath, vcpkgVersion);
       await bootstrapVcpkg(vcpkgExtractedPath);

--- a/src/setup-build-tools/index.js
+++ b/src/setup-build-tools/index.js
@@ -201,6 +201,54 @@ async function cacheTool(terrapinTool, toolName, version, url, hash, extract) {
   return toolDir;
 }
 
+async function run__ccache(terrapinTool, version, hash, addToPath) {
+  const platform = getPlatformIdentifier();
+  const platformSuffix =
+    platform === 'macos' ? 'darwin.tar.gz' :
+      platform == 'linux' ? `linux-${getArchIdentifier()}-musl-static.tar.xz` :
+        platform === 'windows' ? `windows-${getArchIdentifier()}.zip` :
+          new Error(`Unsupported platform for CCache download: ${platform}`);
+
+  const ccacheDir = await cacheTool(
+    terrapinTool,
+    "ccache", version,
+    `https://github.com/ccache/ccache/releases/download/v${version}/ccache-${version}-${platformSuffix}`, hash,
+    async (download) => {
+      core.debug(`Extracting ${download}...`);
+      const extractDir = platform === 'windows'
+        ? await tc.extractZip(download)
+        : await tc.extractTar(download, undefined, 'x'); // infer extract type from extension
+      core.debug(`Extracted archive to temporary location: ${extractDir}`);
+
+      const dirs = fs.readdirSync(extractDir).filter((f) => fs.statSync(path.join(extractDir, f)).isDirectory());
+      if (dirs.length !== 1) throw new Error(
+        `Could not locate extracted ccache directory in ${extractDir}. Found: ${dirs.join(', ')}`
+      );
+
+      core.warning(`Assuming single directory '${dirs[0]}' is CCache root.`);
+      return path.join(extractDir, dirs[0]);
+    });
+  core.info(`Located extracted CCache root at: ${ccacheDir}`);
+
+  if (addToPath) {
+    core.info(`Adding ${ccacheDir} to PATH.`);
+    addPath(ccacheDir);
+
+    try {
+      // Verify Installation via PATH
+      await exec.exec('ccache', ['--version']);
+    } catch (error) {
+      throw new Error(`Verification 'ccache --version' failed: ${error.message}. Check PATH or CCache installation.`, { cause: error });
+    }
+  } else {
+    core.info(`Skipping adding ${ccacheDir} to PATH.`);
+  }
+
+  // for now they're the same, but let's keep it separate for consistency with CMake
+  core.setOutput('ccache-root', ccacheDir);
+  core.setOutput('ccache-path', ccacheDir);
+}
+
 async function run__cmake(terrapinTool, version, hash, addToPath) {
   const platform = getPlatformIdentifier();
   const arch = getArchIdentifier();
@@ -216,7 +264,7 @@ async function run__cmake(terrapinTool, version, hash, addToPath) {
       const extractDir = cmakeFileExtension === 'zip'
         ? await tc.extractZip(download)
         : await tc.extractTar(download);
-      core.debug(`Extracted CMake archive to temporary location: ${extractDir}`);
+      core.debug(`Extracted archive to temporary location: ${extractDir}`);
 
       // Locate CMake Directory
       const maybeRoot = path.join(extractDir, cmakeFileName);
@@ -274,7 +322,10 @@ async function run__vcpkg(terrapinTool, version, hash) {
 // --- Main Orchestration Function ---
 async function run() {
   try {
-    // --- Get Combined Inputs ---
+    const ccacheVersion = core.getInput('ccache-version', { required: true });
+    const ccacheHash = core.getInput('ccache-hash', { required: true });
+    const addCCacheToPath = core.getBooleanInput('add-ccache-to-path');
+
     const cmakeVersion = core.getInput('cmake-version', { required: true });
     const cmakeHash = core.getInput('cmake-hash', { required: true });
     const addCMakeToPath = core.getBooleanInput('add-cmake-to-path');
@@ -286,6 +337,7 @@ async function run() {
     const allowTerrapin = !core.getBooleanInput('disable-terrapin'); // keep logic positive to minimise double negatives
 
     const terrapinTool = terrapinAvailable(terrapinPath, allowTerrapin) ? terrapinPath : null;
+    await core.group(`Setup ccache`, async () => { await run__ccache(terrapinTool, ccacheVersion, ccacheHash, addCCacheToPath) });
     await core.group(`Setup cmake`, async () => { await run__cmake(terrapinTool, cmakeVersion, cmakeHash, addCMakeToPath) });
     await core.group(`Setup vcpkg`, async () => { await run__vcpkg(terrapinTool, vcpkgVersion, vcpkgHash) });
   } catch (error) {

--- a/test/common/utils.test.js
+++ b/test/common/utils.test.js
@@ -13,7 +13,7 @@ const utils = require('../../src/common/utils'); // Adjust path as needed
 // Mock dependencies
 jest.mock('@actions/core');
 jest.mock('@actions/exec');
-jest.mock('@actions/glob'); 
+jest.mock('@actions/glob');
 // Mocking crypto
 const mockUpdate = jest.fn();
 const mockDigest = jest.fn();
@@ -172,7 +172,8 @@ describe('Common Utils', () => {
       expect(crypto.createHash).toHaveBeenCalledWith('sha512');
       expect(mockUpdate).toHaveBeenCalledTimes(2); // Called twice in mock stream
       expect(mockDigest).toHaveBeenCalledWith('hex');
-      expect(core.info).toHaveBeenCalledWith(expect.stringContaining('Verification Result for file.zip: Match'));
+      expect(core.info).toHaveBeenCalledTimes(1); // success should write exactly once to info ('calculating hash...')
+      expect(core.debug).toHaveBeenCalled(); // success should note it in debug logs
     });
 
     it('should return false for non-matching hash', async () => {
@@ -182,7 +183,7 @@ describe('Common Utils', () => {
 
       expect(result).toBe(false);
       expect(mockDigest).toHaveBeenCalledWith('hex');
-      expect(core.info).toHaveBeenCalledWith(expect.stringContaining('Verification Result for file.zip: Mismatch'));
+      expect(core.warning).toHaveBeenCalled(); // should write to warning on failure
     });
 
     it('should reject if stream emits error', async () => {


### PR DESCRIPTION
setup-build-tools:
- refactor/deduplicate code
- add ccache as a required build tool
- cmake no longer accepts `latest` version
- cmake now requires a SHA512 for validation

build-and-prep-ort-files:
- use ccache w/ CCACHE_DIR pointed to `~/.cache/ccache`

build-minimal-ort-and-run-tests:
- use ccache w/ CCACHE_DIR pointed to `~/.cache/ccache`

run-build-script-in-docker:
- change assumed ccache directory from `~/.ccache` to `~/.cache/ccache` for consistency w/ other actions