### PR TITLE
Make vcpkg optional and enabled by default

### DIFF
--- a/actions/run-build-script-in-docker/action.yml
+++ b/actions/run-build-script-in-docker/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: 'Value for NIGHTLY_BUILD env var'
     required: false
     default: '1'
+  use_vcpkg:
+    description: 'Use vcpkg tool'
+    required: false
+    default: '1'
 
 runs:
   using: 'node24'

--- a/actions/run-build-script-in-docker/action.yml
+++ b/actions/run-build-script-in-docker/action.yml
@@ -37,7 +37,7 @@ inputs:
   use_vcpkg:
     description: 'Use vcpkg tool'
     required: false
-    default: '1'
+    default: 'true'
 
 runs:
   using: 'node24'

--- a/src/run-build-script-in-docker/index.js
+++ b/src/run-build-script-in-docker/index.js
@@ -78,6 +78,7 @@ async function run() {
         const pythonPathPrefix = core.getInput('python_path_prefix'); // Get prefix input
         const allowOpset = core.getInput('allow_released_opset_only');
         const nightlyBuild = core.getInput('nightly_build');
+        const useVcpkg = core.getInput('use_vcpkg');
 
         // --- Validate Mode ---
         let buildPyArg;
@@ -156,8 +157,7 @@ async function run() {
             '--skip_submodule_sync',
             '--build_shared_lib',
             '--parallel',
-            '--use_vcpkg',
-            '--use_vcpkg_ms_internal_asset_cache',
+            ...(useVcpkg ? ['--use_vcpkg', '--use_vcpkg_ms_internal_asset_cache'] : []),
             ...(enableOnnxTestsFlag ? ['--enable_onnx_tests'] : []),
             ...epFlags,
             extraBuildFlags,

--- a/src/run-build-script-in-docker/index.js
+++ b/src/run-build-script-in-docker/index.js
@@ -78,7 +78,7 @@ async function run() {
         const pythonPathPrefix = core.getInput('python_path_prefix'); // Get prefix input
         const allowOpset = core.getInput('allow_released_opset_only');
         const nightlyBuild = core.getInput('nightly_build');
-        const useVcpkg = core.getInput('use_vcpkg');
+        const useVcpkg = core.getBooleanInput('use_vcpkg');
 
         // --- Validate Mode ---
         let buildPyArg;


### PR DESCRIPTION
Make vcpkg optional and enabled by default.

Option for build without vcpkg is needed for platforms where vcpkg is not available at the moment, like s390x.

Additional testing is needed to ensure that everything works as intended, only basic testing was done.